### PR TITLE
DLPX-92524 Update to go 1.23 to enable github workers

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@
 	dh $@
 
 override_dh_install:
-	./scripts/fetch-and-run-installer.sh "1.20.4" "/usr" "debian/tmp"
+	./scripts/fetch-and-run-installer.sh "1.23.2" "/usr" "debian/tmp"
 
 	dh_install --autodest "debian/tmp/*"
 


### PR DESCRIPTION
The github workers have updated to not include go 1.20 anymore, which will break our checkstyle runs. We need to update to a newer version.

https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/9717/console